### PR TITLE
allow for more attributes when creating taskwarrior tasks

### DIFF
--- a/egtlib/body.py
+++ b/egtlib/body.py
@@ -175,16 +175,16 @@ class Body:
 
         # Get everything until we reach the end of file
         while True:
-            l = lines.next()
+            line = lines.next()
             # Stop at an empty line or at EOF
-            if l is None: break
-            mo = self.re_task.match(l)
+            if line is None: break
+            mo = self.re_task.match(line)
             if mo is not None:
                 task = Task(self, **mo.groupdict())
                 self.content.append(task)
                 self.tasks.append(task)
             else:
-                self.content.append(Line(l))
+                self.content.append(Line(line))
 
     def sync_tasks(self):
         """

--- a/egtlib/lang.py
+++ b/egtlib/lang.py
@@ -36,6 +36,7 @@ class ItalianParserInfo(dateutil.parser.parserinfo):
         # for german dates, set ``dayfirst`` by default
         super(ItalianParserInfo, self).__init__(dayfirst=dayfirst, yearfirst=yearfirst)
 
+
 by_lang = dict(
     en=dateutil.parser.parserinfo,
     it=ItalianParserInfo,

--- a/egtlib/meta.py
+++ b/egtlib/meta.py
@@ -49,10 +49,10 @@ class Meta:
 
         # Get everything until we reach an empty line
         while True:
-            l = lines.next()
+            line = lines.next()
             # Stop at an empty line or at EOF
-            if not l: break
-            self._lines.append(l)
+            if not line: break
+            self._lines.append(line)
 
         # Parse fields in the same way as email headers
         import email

--- a/egtlib/parse.py
+++ b/egtlib/parse.py
@@ -45,7 +45,7 @@ class Lines:
 
     def skip_empty_lines(self):
         while True:
-            l = self.peek()
-            if l is None: break
-            if l: break
+            line = self.peek()
+            if line is None: break
+            if line: break
             self.discard()

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -39,7 +39,7 @@ class TestCommands(ProjectTestMixin, unittest.TestCase):
         self.assertIn("test", state.projects)
         self.assertIn("p1", state.projects)
         self.assertIn("p2", state.projects)
-        self.assertEquals(len(state.projects), 3)
+        self.assertEqual(len(state.projects), 3)
 
     def test_list(self):
         State.rescan([self.workdir.name], statedir=self.workdir.name)
@@ -48,7 +48,7 @@ class TestCommands(ProjectTestMixin, unittest.TestCase):
         self.assertIn("test", names)
         self.assertIn("p1", names)
         self.assertIn("p2", names)
-        self.assertEquals(len(names), 3)
+        self.assertEqual(len(names), 3)
 
     # TODO: test_summary
     # TODO: test_term
@@ -81,4 +81,4 @@ class TestCommands(ProjectTestMixin, unittest.TestCase):
         self.assertIn(os.path.join(wd, ".egt"), names)
         self.assertIn(os.path.join(wd, "p1.egt"), names)
         self.assertIn(os.path.join(wd, "p2.egt"), names)
-        self.assertEquals(len(names), 3)
+        self.assertEqual(len(names), 3)

--- a/test/test_lints.py
+++ b/test/test_lints.py
@@ -60,4 +60,4 @@ class TestPep8Clean(unittest.TestCase):
     """ ensure that the tree is pep8 clean """
 
     def test_pep8_clean(self):
-        self.assertEqual(run_check("pep8", basedir), 0)
+        self.assertEqual(run_check("pycodestyle", basedir), 0)


### PR DESCRIPTION
Hi Enrico

I added the code to allow setting more attributes from the .egt files. Personally I'll probably need due and wait. 
Doing this I also hit a problem in taskw. It's reported there and I implemented a workaround. (see egtlib/body.py:83)

In addition, the first 3 commits make the tests work silently. Sorry, they probably should have gone into a separate pull request.

best wishes
Nicola