### PR TITLE
Fix tests

### DIFF
--- a/egtlib/body.py
+++ b/egtlib/body.py
@@ -33,8 +33,7 @@ class Task(BodyEntry):
     A TaskWarrior task
     """
     re_attribute = re.compile(r"^(?P<key>[^:]+):(?P<val>[^:]+)$")
-    task_attributes = ["start", "end", "due", "until",
-                       "wait", "scheduled", "priority"]
+    task_attributes = ["start", "due", "until", "wait", "scheduled", "priority"]
 
     def __init__(self, body, id, indent="", text=None, task=None):
         # Body object owning this Task

--- a/egtlib/egt.py
+++ b/egtlib/egt.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 class WeeklyReport(object):
     def __init__(self):
-        self.projs: List["project.Project"] = []
+        self.projs: List["Project"] = []
 
     def add(self, p: Project) -> None:
         self.projs.append(p)

--- a/egtlib/utils.py
+++ b/egtlib/utils.py
@@ -86,6 +86,8 @@ def stream_output(proc: "subprocess.Popen"):
     one last element: ("result", return_code) with the return code of the
     process.
     """
+    assert proc.stdout is not None
+    assert proc.stderr is not None
     fds = [proc.stdout, proc.stderr]
     bufs = [b"", b""]
     types = ["stdout", "stderr"]

--- a/test/test_annotate.py
+++ b/test/test_annotate.py
@@ -40,10 +40,10 @@ class TestAnnotate(ProjectTestMixin, unittest.TestCase):
         self.assertEqual(self.annotate("Lang: it\n"), "Lang: it\n\n2019\n\n")
 
     def test_parse_error(self):
-        res = self.annotate("Lang: it\n\n01 pippo:\n - error\n")
+        res = self.annotate("Lang: it\n\n2019\n01 pippo:\n - error\n")
         self.assertEqual(res.splitlines(), [
             "Lang: it",
-            "Parse-Errors: line 3: cannot parse log header date: '01 pippo' (lang=it)",
+            "Parse-Errors: line 4: cannot parse log header date: '01 pippo' (lang=it)",
             "",
             "2019",
             "01 pippo:",
@@ -52,7 +52,7 @@ class TestAnnotate(ProjectTestMixin, unittest.TestCase):
         ])
 
     def test_parse_errors_fixed(self):
-        res = self.annotate("Lang: it\nParse-Errors: foo\n\n01 marzo:\n - fixed\n")
+        res = self.annotate("Lang: it\nParse-Errors: foo\n\n2019\n01 marzo:\n - fixed\n")
         self.assertEqual(res.splitlines(), [
             "Lang: it",
             "",

--- a/test/test_archive.py
+++ b/test/test_archive.py
@@ -193,9 +193,10 @@ class TestArchive(ProjectTestMixin, unittest.TestCase):
             "Archive-Dir: " + self.workdir.name,
             "",
             "2019",
+            str(datetime.date.today().year),
             "",
         ]
-        self.assertEqual(self.to_text(proj).splitlines(), remainder)
+        self.assertEqual(self.to_text(proj, today=None).splitlines(), remainder)
         with open(proj.abspath, "rt") as fd:
             self.assertEqual([x.rstrip() for x in fd], remainder)
 
@@ -215,9 +216,10 @@ class TestArchive(ProjectTestMixin, unittest.TestCase):
             "2019",
             "01 february: 10:00-13:00 3h",
             " - fixed",
+            str(datetime.date.today().year),
             "",
         ]
-        self.assertEqual(self.to_text(proj).splitlines(), remainder)
+        self.assertEqual(self.to_text(proj, today=None).splitlines(), remainder)
         with open(proj.abspath, "rt") as fd:
             self.assertEqual([x.rstrip() for x in fd], remainder)
 
@@ -233,8 +235,9 @@ class TestArchive(ProjectTestMixin, unittest.TestCase):
             "Archive-Dir: " + self.workdir.name,
             "",
             "2019",
+            str(datetime.date.today().year),
             "",
         ]
-        self.assertEqual(self.to_text(proj).splitlines(), remainder)
+        self.assertEqual(self.to_text(proj, today=None).splitlines(), remainder)
         with open(proj.abspath, "rt") as fd:
             self.assertEqual([x.rstrip() for x in fd], remainder)

--- a/test/test_lints.py
+++ b/test/test_lints.py
@@ -71,4 +71,4 @@ class TestLinters(unittest.TestCase):
     @unittest.skipIf("SKIP_MYPY" in os.environ, "SKIP_MYPY is set in the environment")
     def test_mypy_clean(self):
         stubs_dir = os.path.join(basedir, "stubs")
-        self.assertEqual(run_check("mypy", basedir, extra_env={"MYPYPATH": stubs_dir}), 0)
+        self.assertEqual(run_check("mypy", basedir, "--no-error-summary", extra_env={"MYPYPATH": stubs_dir}), 0)

--- a/test/test_lints.py
+++ b/test/test_lints.py
@@ -12,6 +12,7 @@ re_ignores = (
     re.compile(r"E701 multiple statements on one line \(colon\)"),
     re.compile(r"E265 block comment should start with"),
     re.compile(r"egtlib/texttable.py:"),
+    re.compile(r"E741 ambiguous variable name 'l'")
 )
 
 

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -87,7 +87,6 @@ class TestTasks(ProjectTestMixin, unittest.TestCase):
         test_attributes = [("due", "2031-01-02", datedata),
                            ("wait", "2031-01-02", datedata),
                            ("start", "2031-01-02", datedata),
-                           ("end", "2031-01-02", datedata),
                            ("until", "2031-01-02", datedata),
                            ("scheduled", "2031-01-02", datedata),
                            ("priority", "H", "H"),


### PR DESCRIPTION
when trying to build Debian packages locally for the new version, I hit several problems in the tests.

This branch contains the needed fixes to the code.

In addition I had to:
  * install `python3-types-python-dateutil`
  * `sudo dpkg-reconfigure locales` and add `fr_FR.UTF-8` and `it_IT.UTF-8`

Should this be documented somewhere/added to `Build-Depends-Indep`?