### PR TITLE
new subcomand: cat

### DIFF
--- a/completion-egt.sh
+++ b/completion-egt.sh
@@ -1,27 +1,27 @@
 _egt() {
-	COMPREPLY=()
-	local cur="${COMP_WORDS[COMP_CWORD]}"
-	local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    COMPREPLY=()
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-	case "$prev" in
+    case "$prev" in
         egt)
-			local commands=$(egt completion commands)
-			COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+            local commands=$(egt completion commands)
+            COMPREPLY=($(compgen -W "$commands" -- "$cur"))
             return 0
         ;;
-		-t|--tag)
-			local tags=$(egt completion tags)
-			COMPREPLY=($(compgen -W "$tags" -- "$cur"))
-		;;
+        -t|--tag)
+            local tags=$(egt completion tags)
+            COMPREPLY=($(compgen -W "$tags" -- "$cur"))
+        ;;
     esac
 
-	local base="${COMP_WORDS[1]}"
-	case "$base" in
-		edit|grep|term|work|print_log)
-			local projects=$(egt completion projects)
-			COMPREPLY=($(compgen -W "$projects" -- "$cur"))
-		;;
-	esac
-	return 0
+    local base="${COMP_WORDS[1]}"
+    case "$base" in
+        edit|grep|term|work|print_log)
+            local projects=$(egt completion projects)
+            COMPREPLY=($(compgen -W "$projects" -- "$cur"))
+        ;;
+    esac
+    return 0
 } 
 complete -F _egt egt

--- a/completion-egt.sh
+++ b/completion-egt.sh
@@ -17,7 +17,7 @@ _egt() {
 
     local base="${COMP_WORDS[1]}"
     case "$base" in
-        edit|grep|term|work|print_log)
+        edit|grep|term|work|cat)
             local projects=$(egt completion projects)
             COMPREPLY=($(compgen -W "$projects" -- "$cur"))
         ;;

--- a/completion-egt.sh
+++ b/completion-egt.sh
@@ -4,13 +4,22 @@ _egt() {
 	local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
 	case "$prev" in
-		edit|grep|term|work)
-			local projects=$(egt completion projects)
-			COMPREPLY=($(compgen -W "$projects" -- "$cur"))
-		;;
+        egt)
+			local commands=$(egt completion commands)
+			COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+            return 0
+        ;;
 		-t|--tag)
 			local tags=$(egt completion tags)
 			COMPREPLY=($(compgen -W "$tags" -- "$cur"))
+		;;
+    esac
+
+	local base="${COMP_WORDS[1]}"
+	case "$base" in
+		edit|grep|term|work|print_log)
+			local projects=$(egt completion projects)
+			COMPREPLY=($(compgen -W "$projects" -- "$cur"))
 		;;
 	esac
 	return 0

--- a/egt
+++ b/egt
@@ -30,14 +30,18 @@ def main():
     else:
         logging.basicConfig(level=logging.WARN, stream=sys.stderr, format=FORMAT)
 
-    if args.command:
-        action = args.command(args)
-        try:
-            action.main()
-        except CommandError as e:
-            print(e, file=sys.stderr)
-            sys.exit(1)
+    try:
+        command = args.command
+    except AttributeError:
+        parser.print_help(sys.stdout)
+        sys.exit(1)
 
+    action = command(args)
+    try:
+        action.main()
+    except CommandError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/egtlib/commands.py
+++ b/egtlib/commands.py
@@ -451,8 +451,11 @@ class Completion(Command):
     """
     def main(self):
         if not self.args.subcommand:
-            raise CommandError("Usage: egt completion {projects|tags|contexts}")
-        if self.args.subcommand == "projects":
+            raise CommandError("Usage: egt completion {commands|projects|tags}")
+        if self.args.subcommand == "commands":
+            for c in Command.COMMANDS:
+                print(c.get_name())
+        elif self.args.subcommand == "projects":
             e = self.make_egt()
             names = e.project_names
             for n in names:
@@ -464,15 +467,8 @@ class Completion(Command):
                 res |= p.tags
             for n in sorted(res):
                 print(n)
-        elif self.args.subcommand == "contexts":
-            e = self.make_egt()
-            res = set()
-            for p in e.projects:
-                res |= p.contexts
-            for n in sorted(res):
-                print(n)
         else:
-            raise CommandError("Usage: egt completion {projects|tags|contexts}")
+            raise CommandError("Usage: egt completion {commands|projects|tags}")
 
     @classmethod
     def add_args(cls, subparser):

--- a/egtlib/commands.py
+++ b/egtlib/commands.py
@@ -352,6 +352,38 @@ class PrintLog(Command):
 
 
 @Command.register
+class Cat(Command):
+    """
+    Output the content of one or more project files
+    """
+    NAME = "cat"
+
+    def main(self):
+        if self.args.log:
+            # delegate to separate command
+            action = PrintLog(self.args)
+            action.main()
+            return
+
+        e = self.make_egt(self.args.projects)
+        for p in e.projects:
+            if self.args.annotate:
+                p.annotate()
+                p.print(sys.stdout)
+            else:
+                with open(p.abspath) as fd:
+                    print(fd.read(), end="")
+
+    @classmethod
+    def add_args(cls, subparser):
+        super().add_args(subparser)
+        group = subparser.add_mutually_exclusive_group()
+        group.add_argument("-a", "--annotate", action="store_true", help="run output through annotate (useful to get up-to-date task-numbers, might create new tasks)")
+        group.add_argument("-l", "--log", action="store_true", help="limit output to project log")
+        subparser.add_argument("projects", nargs="*", help="project(s) to work on")
+
+
+@Command.register
 class Annotate(Command):
     """
     Print a project file on stdout, annotating its contents with anything

--- a/egtlib/commands.py
+++ b/egtlib/commands.py
@@ -343,7 +343,7 @@ class PrintLog(Command):
                 log_entry.print(sys.stdout)
         else:
             for log_entry, p in log:
-                log_entry.print(sys.stdout)
+                log_entry.print(sys.stdout, p)
 
     @classmethod
     def add_args(cls, subparser):

--- a/egtlib/log.py
+++ b/egtlib/log.py
@@ -261,7 +261,7 @@ class Entry(EntryBase):
         line += ["+" + tag for tag in self.tags]
 
         if project is not None:
-            line.append("[%s]" % project)
+            line.append("[%s]" % project.name)
 
         print(" ".join(line), file=file)
 

--- a/project.md
+++ b/project.md
@@ -181,7 +181,7 @@ entries by writing a special header line at the end of the log:
 
 For example, if you run this through `egt annotate`:
 
-``
+```
 2016
 15 January: 14:00-17:00
  - done something
@@ -190,7 +190,7 @@ For example, if you run this through `egt annotate`:
 
 then it becomes (assuming that today is the 16th of March):
 
-``
+```
 2016
 15 January: 14:00-17:00 3h
  - done something
@@ -209,7 +209,7 @@ And if you run this through `egt annotate`:
 
 then it becomes (assuming that today is the 16th of March):
 
-``
+```
 2016
 15 January:
  - done something


### PR DESCRIPTION
This pull request adds a new subcomand "cat". (Changes are on top of PR#8 and only 1 commit.)

Things to discuss:
  * Is a separate command really needed? Most of the functionality is available from `print_log` and `annotate` already. I reuse this for the corresponding flags. `cat` is however shorter to type and in my eyes a more natural name. (After all I did not realize that `annotate` is not just "internal" for the VI integration but already mostly does what I want...)
  * Should `-a` be the default? In most cases, I want the current taskwarrior task numbers. However, `egt cat -a` will turn any `t not yet created task` into a new task, without updating that line. So running the command twice will create two tasks. This is not what one wants, so I decided for the "safe" default.  
Possible solutions: 
     * split the task-update and the task-create part from annotate into a two separate functions.
     * add a `--in-place` option to `annotate` that writes back to the file.