### PR TITLE
Split task-specific implementation from body.py to a separate module

### DIFF
--- a/egtlib/body.py
+++ b/egtlib/body.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, List, Optional, TextIO
-
-import taskw
+from typing import List, Optional, TextIO
 
 from . import project
 from .parse import Lines
@@ -42,10 +40,10 @@ class Body:
     re_task = re.compile(r"^(?P<indent>\s*)t(?P<id>\d*)\s+(?P<text>.+)$")
 
     def __init__(self, project: "project.Project"):
-        from .body_task import Task
+        from .body_task import Tasks
 
         self.project = project
-        self.date_format = self.project.config.date_format
+        self.tasks = Tasks(self)
 
         # Line number in the project file where the body starts
         self._lineno: Optional[int] = None
@@ -53,171 +51,17 @@ class Body:
         # Text lines for the project body
         self.content: List[BodyEntry] = []
 
-        # Just the Task entries, for easy access
-        self.tasks: List[Task] = []
-
-        # Storage for handling annotations
-        self._new_log: Dict[str, List[Line]] = {}
-        self._known_annotations: List[List[str]] = []  # using list instead of tuple due to json constraints
-
-        # Taskwarrior interface, loaded lazily
-        self._tw: Optional[taskw.TaskWarrior] = None
-
-    def force_load_tw(self, **kw):
-        """
-        Force lazy loading of TaskWarrior object, possibly with custom extra
-        arguments.
-
-        This is used in tests to instantiate TaskWarrior objects pointing to
-        the test TaskWarrior configuration.
-        """
-        self._tw = taskw.TaskWarrior(marshal=True, **kw)
-
-    @property
-    def tw(self) -> taskw.TaskWarrior:
-        if self._tw is None:
-            self._tw = taskw.TaskWarrior(marshal=True)
-        return self._tw
-
     def parse(self, lines: Lines) -> None:
-        from .body_task import Task
-
         self._lineno = lines.lineno
 
         # Get everything until we reach the end of file
         for line in lines.rest():
             if (mo := self.re_task.match(line)):
-                task = Task(self, **mo.groupdict())
-                self.content.append(task)
-                self.tasks.append(task)
+                self.content.append(self.tasks.create_task(**mo.groupdict()))
             else:
                 self.content.append(Line(line))
 
-        # load known annotations from state file
-        known_annotations = self.project.state.get("annotations")
-        if known_annotations:
-            self._known_annotations = known_annotations
-
-    def new_log(self, date, line):
-        try:
-            self._new_log[date].append(line)
-        except KeyError:
-            self._new_log[date] = [line]
-
-    def _sync_annotations(self, task) -> None:
-        """
-        Sync annotations between task and TaskWarrior
-        """
-        try:
-            annotations = task["annotations"]
-        except KeyError:
-            return
-        for annotation in annotations:
-            entry = [str(task["uuid"]), annotation.entry.isoformat()]  # isoformat as used internally only
-            if entry in self._known_annotations:
-                continue
-            self._known_annotations.append(entry)
-            date = annotation.entry.date().strftime(self.date_format)
-            line = Line("  - {desc}: {annot}".format(desc=task["description"], annot=annotation))
-            self.new_log(date, line)
-
-    def _sync_completed(self, task) -> None:
-        """
-        Add log line for completed tasks
-        """
-        if task["status"] == "completed":
-            date = task["modified"].date().strftime(self.date_format)
-            line = Line(
-                "  - [completed] {desc}".format(
-                    desc=task["description"],
-                )
-            )
-            self.new_log(date, line)
-
-    def sync_tasks(self, modify_state=True) -> None:
-        """
-        Sync the tasks in the body with TaskWarrior
-
-        modify_state:
-            run updates that will modify the state
-              - create new tasks not present in taskwarrior yet
-              - store updated uuids and annotations
-            if true, the body must be written back to the project file
-
-        """
-        from .body_task import Task
-
-        # Load task information from TaskWarrior, for tasks that are already in
-        # TaskWarrior
-        for t in self.tasks:
-            t.resolve_task()
-
-        if modify_state:
-            # Iterate self.tasks creating new tasks in taskwarrior
-            for t in self.tasks:
-                if t.is_new:
-                    t.create()
-
-        # Load UUIDs of tasks known to have been completed or deleted
-        try:
-            old_uuids = set(self.project.state.get("tasks")["old_uuids"])
-        except (TypeError, KeyError):
-            old_uuids = set()
-
-        # Collect known UUIDs (old tasks + tasks in project-file)
-        known_uuids = old_uuids.copy()
-        for t in self.tasks:
-            if t.task is None:
-                continue
-            known_uuids.add(str(t.task["uuid"]))
-
-        # Process all tasks known to taskwarrior
-        new = []
-        for tw_task in self.tw.filter_tasks({"project.is": self.project.name}):
-            uuid = str(tw_task["uuid"])
-            if self.project.config.sync_tw_annotations:
-                self._sync_annotations(tw_task)
-            # handle completed and deleted tasks
-            if tw_task["id"] == 0 and uuid not in old_uuids:
-                self._sync_completed(tw_task)
-                old_uuids.add(uuid)
-                continue
-            # handle reactivated tasks
-            if uuid in old_uuids and tw_task["id"] != 0:
-                old_uuids.remove(uuid)
-                known_uuids.remove(uuid)
-            # skip tasks that exist in project-file already
-            if uuid in known_uuids:
-                continue
-            # Add remaining Taskwarrior tasks to project-file
-            task = Task(self, tw_task["id"], task=tw_task)
-            new.append(task)
-
-        # If we created new task-content, prepend it to self.tasks and self.content
-        if new:
-            self.tasks[0:0] = new
-            self.content[0:0] = new + [Line("")]
-
-        # If we created new log-content, prepend it to self.content
-        if self._new_log:
-            content = []
-            for key, lines in sorted(self._new_log.items()):
-                content.append(Line(key + ":"))
-                content += lines
-            content.append(Line(""))
-            self.content[0:0] = content
-
-        # Rebuild state and save it
-        if modify_state:
-            ids = {}
-            for t in self.tasks:
-                if t.is_orphan:
-                    continue
-                if t.id is None:
-                    continue
-                ids[t.id] = str(t.task["uuid"])
-            self.project.state.set("tasks", {"ids": ids, "old_uuids": list(old_uuids)})
-            self.project.state.set("annotations", self._known_annotations)
+        self.tasks.post_parse_hook()
 
     def print(self, file: TextIO) -> bool:
         """

--- a/egtlib/body.py
+++ b/egtlib/body.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import re
-import shlex
-from typing import Dict, List, Optional, TextIO, Union
+from typing import Dict, List, Optional, TextIO
 
 import taskw
 
@@ -34,156 +33,6 @@ class Line(BodyEntry):
         return "Line({})".format(repr(self.line))
 
 
-class Task(BodyEntry):
-    """
-    A TaskWarrior task
-    """
-
-    re_attribute = re.compile(r"^(?P<key>[^:]+):(?P<val>[^:]+)$")
-    task_attributes = ["start", "due", "until", "wait", "scheduled", "priority"]
-
-    def __init__(
-            self,
-            body: "Body",
-            id: Union[int, str],
-            indent: str = "",
-            text: Optional[str] = None,
-            task=None) -> None:
-        # Body object owning this Task
-        self.body = body
-        # Indentation at the beginning of the lines
-        self.indent = indent
-        # Taskwarrior task dict (None means no mapping attempted yet)
-        self.set_twtask(task)
-        self.id: Optional[int]
-        if isinstance(id, int):
-            # Whether the task is new and needs to be created in TaskWarrior
-            self.is_new = False
-            # Task ID currently used in egt
-            self.id = id
-        else:
-            self.is_new = not id.isdigit()
-            self.id = int(id) if id else None
-
-        if task is not None:
-            self.desc = task["description"]
-            self.tags = set(task["tags"]) if "tags" in task else set()
-        elif text is not None:
-            # Parse the text
-            desc = []
-            tags = set()
-            attributes = {}
-            for word in shlex.split(text):
-                if word.startswith("+"):
-                    tags.add(word[1:])
-                else:
-                    attr = self.re_attribute.match(word)
-                    if attr is not None:
-                        key, val = attr.groups()
-                        if key in self.task_attributes:
-                            attributes[key] = val
-                        else:
-                            desc.append(word)
-                    else:
-                        desc.append(word)
-
-            # Rebuild the description
-            self.desc = " ".join(shlex.quote(x) for x in desc)
-
-            # Tags
-            self.tags = tags
-            self.attributes = attributes
-
-            # TODO Not handling dependencies from egt yet
-            self.depends: set[int] = set()
-        else:
-            raise ValueError("One of text or task must be provided")
-
-        # If True, then we lost the mapping with TaskWarrior
-        self.is_orphan = False
-
-    def create(self):
-        """
-        Create the task in TaskWarrior
-        """
-        if not self.is_new:
-            return
-        tags = self.body.project.tags | self.tags
-        # the following lines are a workaround for https://github.com/ralphbean/taskw/issues/111
-        self.body.tw._marshal = False
-        newtask = self.body.tw.task_add(self.desc, project=self.body.project.name, tags=sorted(tags), **self.attributes)
-        self.body.tw._marshal = True
-        id, task = self.body.tw.get_task(uuid=newtask["id"])
-        self.set_twtask(task)
-        self.id = self.task["id"]
-        self.is_new = False
-
-    def resolve_task(self):
-        """
-        Resolve a task ID from a project file into a TaskWarrior task.
-
-        Returns None if no mapping has been found.
-        """
-        # If it is new, nothing to do
-        if self.is_new:
-            return
-
-        # Try to resolve id into UUID
-        tasks = self.body.project.state.get("tasks")
-        ids = None
-        if tasks is not None:
-            ids = tasks.get("ids", None)
-            uuid = ids.get(str(self.id), None)
-            if uuid is not None:
-                id, task = self.body.tw.get_task(uuid=uuid)
-                if task:
-                    self.set_twtask(task)
-                    self.id = task["id"] if task["id"] != 0 else None
-                    self.desc = task["description"]
-                    bl = self.body.project.tags
-                    self.tags = set(t for t in task["tags"] if t not in bl) if "tags" in task else set()
-                    return
-
-        # Looking up by uuid failed, try looking up by description
-        id, task = self.body.tw.get_task(description=self.desc)
-        if task:
-            self.set_twtask(task)
-            return
-
-        # Mapping to taskwarrior failed: mark this task as orphan, so
-        # it can be indicated when serializing
-        self.is_orphan = True
-
-    def set_twtask(self, task) -> None:
-        self.task = task
-        self.depends = set()
-        if task:
-            if "depends" in task:
-                depends_uuids = set(task["depends"])
-                self.depends = set(self.body.tw.get_task(uuid=t)[0] for t in depends_uuids)
-
-    def print(self, file):
-        res = []
-        if self.is_orphan:
-            res.append("- [orphan]")
-        elif self.task and self.task["id"] == 0:
-            res.append("-")
-        elif self.id is None:
-            res.append("t")
-        else:
-            res.append("t{}".format(self.id))
-        if self.task:
-            if self.task["status"] == "completed":
-                return
-            res.append("[{:%Y-%m-%d %H:%M} {}]".format(self.task["modified"], self.task["status"]))
-        res.append(self.desc)
-        bl = self.body.project.tags
-        res.extend("+" + t for t in sorted(self.tags) if t not in bl)
-        if self.depends:
-            res.append("depends:" + ",".join(str(t) for t in sorted(self.depends)))
-        print(self.indent + " ".join(res), file=file)
-
-
 class Body:
     """
     The text body of a Project file, as anything that follows the metadata and
@@ -193,6 +42,8 @@ class Body:
     re_task = re.compile(r"^(?P<indent>\s*)t(?P<id>\d*)\s+(?P<text>.+)$")
 
     def __init__(self, project: "project.Project"):
+        from .body_task import Task
+
         self.project = project
         self.date_format = self.project.config.date_format
 
@@ -229,6 +80,8 @@ class Body:
         return self._tw
 
     def parse(self, lines: Lines) -> None:
+        from .body_task import Task
+
         self._lineno = lines.lineno
 
         # Get everything until we reach the end of file
@@ -292,6 +145,8 @@ class Body:
             if true, the body must be written back to the project file
 
         """
+        from .body_task import Task
+
         # Load task information from TaskWarrior, for tasks that are already in
         # TaskWarrior
         for t in self.tasks:

--- a/egtlib/body_task.py
+++ b/egtlib/body_task.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import re
 import shlex
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-# import taskw
+import taskw
 
-from .body import BodyEntry
+from .body import BodyEntry, Line
 
 if TYPE_CHECKING:
     from .body import Body
@@ -22,7 +22,7 @@ class Task(BodyEntry):
 
     def __init__(
             self,
-            body: "Body",
+            body: Body,
             id: Union[int, str],
             indent: str = "",
             text: Optional[str] = None,
@@ -88,10 +88,11 @@ class Task(BodyEntry):
             return
         tags = self.body.project.tags | self.tags
         # the following lines are a workaround for https://github.com/ralphbean/taskw/issues/111
-        self.body.tw._marshal = False
-        newtask = self.body.tw.task_add(self.desc, project=self.body.project.name, tags=sorted(tags), **self.attributes)
-        self.body.tw._marshal = True
-        id, task = self.body.tw.get_task(uuid=newtask["id"])
+        self.body.tasks.tw._marshal = False
+        newtask = self.body.tasks.tw.task_add(
+            self.desc, project=self.body.project.name, tags=sorted(tags), **self.attributes)
+        self.body.tasks.tw._marshal = True
+        id, task = self.body.tasks.tw.get_task(uuid=newtask["id"])
         self.set_twtask(task)
         self.id = self.task["id"]
         self.is_new = False
@@ -113,7 +114,7 @@ class Task(BodyEntry):
             ids = tasks.get("ids", None)
             uuid = ids.get(str(self.id), None)
             if uuid is not None:
-                id, task = self.body.tw.get_task(uuid=uuid)
+                id, task = self.body.tasks.tw.get_task(uuid=uuid)
                 if task:
                     self.set_twtask(task)
                     self.id = task["id"] if task["id"] != 0 else None
@@ -123,7 +124,7 @@ class Task(BodyEntry):
                     return
 
         # Looking up by uuid failed, try looking up by description
-        id, task = self.body.tw.get_task(description=self.desc)
+        id, task = self.body.tasks.tw.get_task(description=self.desc)
         if task:
             self.set_twtask(task)
             return
@@ -138,7 +139,7 @@ class Task(BodyEntry):
         if task:
             if "depends" in task:
                 depends_uuids = set(task["depends"])
-                self.depends = set(self.body.tw.get_task(uuid=t)[0] for t in depends_uuids)
+                self.depends = set(self.body.tasks.tw.get_task(uuid=t)[0] for t in depends_uuids)
 
     def print(self, file):
         res = []
@@ -160,3 +161,181 @@ class Task(BodyEntry):
         if self.depends:
             res.append("depends:" + ",".join(str(t) for t in sorted(self.depends)))
         print(self.indent + " ".join(res), file=file)
+
+
+class Tasks:
+    """
+    Handle tasks in a Project Body
+    """
+    def __init__(self, body: Body):
+        self.body = body
+
+        self.date_format = self.body.project.config.date_format
+
+        # Just the Task entries, for easy access
+        self.tasks: List[Task] = []
+
+        # Storage for handling annotations
+        self._new_log: Dict[str, List[Line]] = {}
+        self._known_annotations: List[List[str]] = []  # using list instead of tuple due to json constraints
+
+        # Taskwarrior interface, loaded lazily
+        self._tw: Optional[taskw.TaskWarrior] = None
+
+    def __getitem__(self, index: int) -> Task:
+        return self.tasks.__getitem__(index)
+
+    def __len__(self) -> int:
+        return self.tasks.__len__()
+
+    def force_load_tw(self, **kw):
+        """
+        Force lazy loading of TaskWarrior object, possibly with custom extra
+        arguments.
+
+        This is used in tests to instantiate TaskWarrior objects pointing to
+        the test TaskWarrior configuration.
+        """
+        self._tw = taskw.TaskWarrior(marshal=True, **kw)
+
+    @property
+    def tw(self) -> taskw.TaskWarrior:
+        if self._tw is None:
+            self._tw = taskw.TaskWarrior(marshal=True)
+        return self._tw
+
+    def create_task(self, **kw) -> Task:
+        """
+        Create a Task
+        """
+        task = Task(self.body, **kw)
+        self.tasks.append(task)
+        return task
+
+    def post_parse_hook(self) -> None:
+        """
+        Function called after the body is parsed
+        """
+        # load known annotations from state file
+        known_annotations = self.body.project.state.get("annotations")
+        if known_annotations:
+            self._known_annotations = known_annotations
+
+    def new_log(self, date, line):
+        try:
+            self._new_log[date].append(line)
+        except KeyError:
+            self._new_log[date] = [line]
+
+    def _sync_annotations(self, task) -> None:
+        """
+        Sync annotations between task and TaskWarrior
+        """
+        try:
+            annotations = task["annotations"]
+        except KeyError:
+            return
+        for annotation in annotations:
+            entry = [str(task["uuid"]), annotation.entry.isoformat()]  # isoformat as used internally only
+            if entry in self._known_annotations:
+                continue
+            self._known_annotations.append(entry)
+            date = annotation.entry.date().strftime(self.date_format)
+            line = Line("  - {desc}: {annot}".format(desc=task["description"], annot=annotation))
+            self.new_log(date, line)
+
+    def _sync_completed(self, task) -> None:
+        """
+        Add log line for completed tasks
+        """
+        if task["status"] == "completed":
+            date = task["modified"].date().strftime(self.date_format)
+            line = Line(
+                "  - [completed] {desc}".format(
+                    desc=task["description"],
+                )
+            )
+            self.new_log(date, line)
+
+    def sync_tasks(self, modify_state=True) -> None:
+        """
+        Sync the tasks in the body with TaskWarrior
+
+        modify_state:
+            run updates that will modify the state
+              - create new tasks not present in taskwarrior yet
+              - store updated uuids and annotations
+            if true, the body must be written back to the project file
+
+        """
+        # Load task information from TaskWarrior, for tasks that are already in
+        # TaskWarrior
+        for t in self.tasks:
+            t.resolve_task()
+
+        if modify_state:
+            # Iterate self.tasks creating new tasks in taskwarrior
+            for t in self.tasks:
+                if t.is_new:
+                    t.create()
+
+        # Load UUIDs of tasks known to have been completed or deleted
+        try:
+            old_uuids = set(self.body.project.state.get("tasks")["old_uuids"])
+        except (TypeError, KeyError):
+            old_uuids = set()
+
+        # Collect known UUIDs (old tasks + tasks in project-file)
+        known_uuids = old_uuids.copy()
+        for t in self.tasks:
+            if t.task is None:
+                continue
+            known_uuids.add(str(t.task["uuid"]))
+
+        # Process all tasks known to taskwarrior
+        new = []
+        for tw_task in self.tw.filter_tasks({"project.is": self.body.project.name}):
+            uuid = str(tw_task["uuid"])
+            if self.body.project.config.sync_tw_annotations:
+                self._sync_annotations(tw_task)
+            # handle completed and deleted tasks
+            if tw_task["id"] == 0 and uuid not in old_uuids:
+                self._sync_completed(tw_task)
+                old_uuids.add(uuid)
+                continue
+            # handle reactivated tasks
+            if uuid in old_uuids and tw_task["id"] != 0:
+                old_uuids.remove(uuid)
+                known_uuids.remove(uuid)
+            # skip tasks that exist in project-file already
+            if uuid in known_uuids:
+                continue
+            # Add remaining Taskwarrior tasks to project-file
+            task = Task(self.body, tw_task["id"], task=tw_task)
+            new.append(task)
+
+        # If we created new task-content, prepend it to self.tasks and self.content
+        if new:
+            self.tasks[0:0] = new
+            self.body.content[0:0] = new + [Line("")]
+
+        # If we created new log-content, prepend it to self.content
+        if self._new_log:
+            content = []
+            for key, lines in sorted(self._new_log.items()):
+                content.append(Line(key + ":"))
+                content += lines
+            content.append(Line(""))
+            self.body.content[0:0] = content
+
+        # Rebuild state and save it
+        if modify_state:
+            ids = {}
+            for t in self.tasks:
+                if t.is_orphan:
+                    continue
+                if t.id is None:
+                    continue
+                ids[t.id] = str(t.task["uuid"])
+            self.body.project.state.set("tasks", {"ids": ids, "old_uuids": list(old_uuids)})
+            self.body.project.state.set("annotations", self._known_annotations)

--- a/egtlib/body_task.py
+++ b/egtlib/body_task.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import re
+import shlex
+from typing import TYPE_CHECKING, Optional, Union
+
+# import taskw
+
+from .body import BodyEntry
+
+if TYPE_CHECKING:
+    from .body import Body
+
+
+class Task(BodyEntry):
+    """
+    A TaskWarrior task
+    """
+
+    re_attribute = re.compile(r"^(?P<key>[^:]+):(?P<val>[^:]+)$")
+    task_attributes = ["start", "due", "until", "wait", "scheduled", "priority"]
+
+    def __init__(
+            self,
+            body: "Body",
+            id: Union[int, str],
+            indent: str = "",
+            text: Optional[str] = None,
+            task=None) -> None:
+        # Body object owning this Task
+        self.body = body
+        # Indentation at the beginning of the lines
+        self.indent = indent
+        # Taskwarrior task dict (None means no mapping attempted yet)
+        self.set_twtask(task)
+        self.id: Optional[int]
+        if isinstance(id, int):
+            # Whether the task is new and needs to be created in TaskWarrior
+            self.is_new = False
+            # Task ID currently used in egt
+            self.id = id
+        else:
+            self.is_new = not id.isdigit()
+            self.id = int(id) if id else None
+
+        if task is not None:
+            self.desc = task["description"]
+            self.tags = set(task["tags"]) if "tags" in task else set()
+        elif text is not None:
+            # Parse the text
+            desc = []
+            tags = set()
+            attributes = {}
+            for word in shlex.split(text):
+                if word.startswith("+"):
+                    tags.add(word[1:])
+                else:
+                    attr = self.re_attribute.match(word)
+                    if attr is not None:
+                        key, val = attr.groups()
+                        if key in self.task_attributes:
+                            attributes[key] = val
+                        else:
+                            desc.append(word)
+                    else:
+                        desc.append(word)
+
+            # Rebuild the description
+            self.desc = " ".join(shlex.quote(x) for x in desc)
+
+            # Tags
+            self.tags = tags
+            self.attributes = attributes
+
+            # TODO Not handling dependencies from egt yet
+            self.depends: set[int] = set()
+        else:
+            raise ValueError("One of text or task must be provided")
+
+        # If True, then we lost the mapping with TaskWarrior
+        self.is_orphan = False
+
+    def create(self):
+        """
+        Create the task in TaskWarrior
+        """
+        if not self.is_new:
+            return
+        tags = self.body.project.tags | self.tags
+        # the following lines are a workaround for https://github.com/ralphbean/taskw/issues/111
+        self.body.tw._marshal = False
+        newtask = self.body.tw.task_add(self.desc, project=self.body.project.name, tags=sorted(tags), **self.attributes)
+        self.body.tw._marshal = True
+        id, task = self.body.tw.get_task(uuid=newtask["id"])
+        self.set_twtask(task)
+        self.id = self.task["id"]
+        self.is_new = False
+
+    def resolve_task(self):
+        """
+        Resolve a task ID from a project file into a TaskWarrior task.
+
+        Returns None if no mapping has been found.
+        """
+        # If it is new, nothing to do
+        if self.is_new:
+            return
+
+        # Try to resolve id into UUID
+        tasks = self.body.project.state.get("tasks")
+        ids = None
+        if tasks is not None:
+            ids = tasks.get("ids", None)
+            uuid = ids.get(str(self.id), None)
+            if uuid is not None:
+                id, task = self.body.tw.get_task(uuid=uuid)
+                if task:
+                    self.set_twtask(task)
+                    self.id = task["id"] if task["id"] != 0 else None
+                    self.desc = task["description"]
+                    bl = self.body.project.tags
+                    self.tags = set(t for t in task["tags"] if t not in bl) if "tags" in task else set()
+                    return
+
+        # Looking up by uuid failed, try looking up by description
+        id, task = self.body.tw.get_task(description=self.desc)
+        if task:
+            self.set_twtask(task)
+            return
+
+        # Mapping to taskwarrior failed: mark this task as orphan, so
+        # it can be indicated when serializing
+        self.is_orphan = True
+
+    def set_twtask(self, task) -> None:
+        self.task = task
+        self.depends = set()
+        if task:
+            if "depends" in task:
+                depends_uuids = set(task["depends"])
+                self.depends = set(self.body.tw.get_task(uuid=t)[0] for t in depends_uuids)
+
+    def print(self, file):
+        res = []
+        if self.is_orphan:
+            res.append("- [orphan]")
+        elif self.task and self.task["id"] == 0:
+            res.append("-")
+        elif self.id is None:
+            res.append("t")
+        else:
+            res.append("t{}".format(self.id))
+        if self.task:
+            if self.task["status"] == "completed":
+                return
+            res.append("[{:%Y-%m-%d %H:%M} {}]".format(self.task["modified"], self.task["status"]))
+        res.append(self.desc)
+        bl = self.body.project.tags
+        res.extend("+" + t for t in sorted(self.tags) if t not in bl)
+        if self.depends:
+            res.append("depends:" + ",".join(str(t) for t in sorted(self.depends)))
+        print(self.indent + " ".join(res), file=file)

--- a/egtlib/cli.py
+++ b/egtlib/cli.py
@@ -26,6 +26,7 @@ class Fail(BaseException):
 
     No stack trace is printed.
     """
+    pass
 
 
 class Command:

--- a/egtlib/project.py
+++ b/egtlib/project.py
@@ -422,7 +422,7 @@ class Project:
         """
         Sync project with taskwarrior
         """
-        self.body.sync_tasks(modify_state=modify_state)
+        self.body.tasks.sync_tasks(modify_state=modify_state)
 
     def annotate(self, today: Optional[datetime.date] = None):
         """

--- a/egtlib/utils.py
+++ b/egtlib/utils.py
@@ -94,9 +94,9 @@ class TaskStatCol(SummaryCol):
     def init_data(self):
         if self._proj is None:
             return
-        tasks = self._proj.body.tw.filter_tasks({"status": "pending"})
+        tasks = self._proj.body.tasks.tw.filter_tasks({"status": "pending"})
         # could not figure out how to do this in one go
-        tasks += self._proj.body.tw.filter_tasks({"status": "waiting"})
+        tasks += self._proj.body.tasks.tw.filter_tasks({"status": "waiting"})
         for task in tasks:
             try:
                 self.task_stats[task["project"]] += 1

--- a/test/test_annotate.py
+++ b/test/test_annotate.py
@@ -25,7 +25,7 @@ class TestAnnotate(ProjectTestMixin, unittest.TestCase):
                     print(line, file=fd)
 
         proj = Project(self.projectfile, statedir=self.workdir.name, config=Config())
-        proj.body.force_load_tw(config_filename=self.taskrc)
+        proj.body.tasks.force_load_tw(config_filename=self.taskrc)
         proj.load()
 
         proj.annotate(today=today)

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -107,7 +107,7 @@ class TestLog(ProjectTestMixin, unittest.TestCase):
             ]
         )
         proj = Project(self.projectfile, statedir=self.workdir.name, config=Config())
-        proj.body.force_load_tw(config_filename=self.taskrc)
+        proj.body.tasks.force_load_tw(config_filename=self.taskrc)
         proj.load()
 
         self.assertEqual(len(proj.log._entries), 3)
@@ -157,7 +157,7 @@ class TestLog(ProjectTestMixin, unittest.TestCase):
             ]
         )
         proj = Project(self.projectfile, statedir=self.workdir.name, config=Config())
-        proj.body.force_load_tw(config_filename=self.taskrc)
+        proj.body.tasks.force_load_tw(config_filename=self.taskrc)
         proj.load()
 
         self.assertEqual(len(proj.log._entries), 4)
@@ -238,7 +238,7 @@ class TestLog(ProjectTestMixin, unittest.TestCase):
             lang="it",
         )
         proj = Project(self.projectfile, statedir=self.workdir.name, config=Config())
-        proj.body.force_load_tw(config_filename=self.taskrc)
+        proj.body.tasks.force_load_tw(config_filename=self.taskrc)
         proj.load()
 
         self.assertEqual(len(proj.log._entries), 3)
@@ -287,7 +287,7 @@ class TestLog(ProjectTestMixin, unittest.TestCase):
             lang="fr",
         )
         proj = Project(self.projectfile, statedir=self.workdir.name, config=Config())
-        proj.body.force_load_tw(config_filename=self.taskrc)
+        proj.body.tasks.force_load_tw(config_filename=self.taskrc)
         proj.load()
 
         self.assertEqual(len(proj.log._entries), 3)

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -44,7 +44,7 @@ class TestTasks(ProjectTestMixin, unittest.TestCase):
             ]
         )
         proj = Project(self.projectfile, statedir=self.workdir.name, config=Config())
-        proj.body.force_load_tw(config_filename=self.taskrc)
+        proj.body.tasks.force_load_tw(config_filename=self.taskrc)
         proj.load()
 
         self.assertEqual(len(proj.body.content), 4)
@@ -60,7 +60,7 @@ class TestTasks(ProjectTestMixin, unittest.TestCase):
         self.assertEqual(task.tags, {"tag"})
         self.assertFalse(task.is_orphan)
 
-        proj.body.sync_tasks()
+        proj.body.tasks.sync_tasks()
 
         self.assertIsNotNone(task.task)
         self.assertFalse(task.is_new)
@@ -111,7 +111,7 @@ class TestTasks(ProjectTestMixin, unittest.TestCase):
                     ]
                 )
                 proj = Project(self.projectfile, statedir=self.workdir.name, config=Config())
-                proj.body.force_load_tw(config_filename=self.taskrc)
+                proj.body.tasks.force_load_tw(config_filename=self.taskrc)
                 proj.load()
 
                 task = proj.body.tasks[0]
@@ -121,7 +121,7 @@ class TestTasks(ProjectTestMixin, unittest.TestCase):
                 self.assertEqual(task.desc, "new test task")
                 self.assertEqual(task.attributes, {key: value})
 
-                proj.body.sync_tasks()
+                proj.body.tasks.sync_tasks()
 
                 self.assertIsNotNone(task.task)
                 self.assertFalse(task.is_new)
@@ -147,13 +147,13 @@ class TestTasks(ProjectTestMixin, unittest.TestCase):
             ]
         )
         proj = Project(self.projectfile, statedir=self.workdir.name, config=Config())
-        proj.body.force_load_tw(config_filename=self.taskrc)
+        proj.body.tasks.force_load_tw(config_filename=self.taskrc)
         proj.load()
 
         self.assertEqual(len(proj.body.content), 2)
         self.assertEqual(len(proj.body.tasks), 0)
 
-        proj.body.sync_tasks()
+        proj.body.tasks.sync_tasks()
 
         self.assertEqual(len(proj.body.content), 5)
         self.assertEqual(len(proj.body.tasks), 2)
@@ -220,7 +220,7 @@ class TestTasks(ProjectTestMixin, unittest.TestCase):
             ]
         )
         proj = Project(self.projectfile, statedir=self.workdir.name, config=Config())
-        proj.body.force_load_tw(config_filename=self.taskrc)
+        proj.body.tasks.force_load_tw(config_filename=self.taskrc)
         proj.load()
 
         self.assertEqual(len(proj.body.content), 3)
@@ -235,7 +235,7 @@ class TestTasks(ProjectTestMixin, unittest.TestCase):
         self.assertEqual(task.tags, set())
         self.assertFalse(task.is_orphan)
 
-        proj.body.sync_tasks()
+        proj.body.tasks.sync_tasks()
 
         self.assertEqual(len(proj.body.tasks), 1)
         self.assertEqual(task, proj.body.tasks[0])
@@ -304,7 +304,7 @@ class TestTasks(ProjectTestMixin, unittest.TestCase):
 
         # Load the project and see
         proj = Project(self.projectfile, statedir=self.workdir.name, config=Config())
-        proj.body.force_load_tw(config_filename=self.taskrc)
+        proj.body.tasks.force_load_tw(config_filename=self.taskrc)
         proj.load()
 
         self.assertEqual(len(proj.body.content), 3)
@@ -319,7 +319,7 @@ class TestTasks(ProjectTestMixin, unittest.TestCase):
         self.assertEqual(task.tags, set())
         self.assertFalse(task.is_orphan)
 
-        proj.body.sync_tasks()
+        proj.body.tasks.sync_tasks()
 
         self.assertEqual(len(proj.body.tasks), 1)
         self.assertEqual(task, proj.body.tasks[0])


### PR DESCRIPTION
Hello,

the tasks-specific implementation is pretty entangled with the general Body implementation, and I've tried to refactor it into a separate source.

I suppose there could be further refactoring from here to clean it up, but first of all I'd like to ask you if you like this approach, and for this I'm proposing the change in a pull request.

Let me know if you see issues, or if this conflicts badly with changes you are working on. Otherwise if you see no problems with this, feel free to just merge